### PR TITLE
update to use @google-cloud/storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "homepage": "https://github.com/EmberSherpa/fastboot-gcloud-storage-downloader#readme",
   "dependencies": {
     "fs-promise": "0.5.0",
-    "gcloud": "0.32.0"
+    "@google-cloud/storage": "^2.3.0"
   }
 }


### PR DESCRIPTION
The `gcloud` package has been deprecated completely, and causes all sorts of npm/yarn dependency issues when compiling

companion PR: https://github.com/EmberSherpa/fastboot-gcloud-storage-notifier/pull/1

Tested this version and it works now